### PR TITLE
Remove backticks from pip install stomp.py command

### DIFF
--- a/tests/CI/pilot_ci.sh
+++ b/tests/CI/pilot_ci.sh
@@ -224,8 +224,8 @@ function installStompRequestsIfNecessary()
       fi
       python get-pip.py --user --upgrade
       echo "$PIP_LOC install --user 'stomp.py==4.1.11'"
-      `${PIP_LOC} install --user 'stomp.py==4.1.11'`
-      `${PIP_LOC} install --user 'requests'`
+      ${PIP_LOC} install --user 'stomp.py==4.1.11'
+      ${PIP_LOC} install --user 'requests'
   fi
   #stomp should be installed now
   python -c 'import stomp' > /dev/null 2>&1 ||{ echo >&2 "stomp installation failure. Aborting"; exit 1; }


### PR DESCRIPTION
I don't understand what these backticks were ever trying to do but fixes this crash in the tests:
https://jenkins-dirac.web.cern.ch/view/LHCbDIRAC/job/LHCbPilot3_CVM4_pipeline/11/console

(Targeting @fstagni's fork so I can pick up https://github.com/DIRACGrid/Pilot/pull/88/.)